### PR TITLE
Toasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ node_modules
 /index.js
 /overlay.js
 /styles.js
+/toast.js
+/toast-container.js

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -3,8 +3,14 @@
 const gulp = require('gulp');
 const babel = require('gulp-babel');
 
+const watch = (process.argv.indexOf('--watch') !== -1);
+
 gulp.task('default', function(){
   return gulp.src('./src/*.js')
     .pipe(babel())
     .pipe(gulp.dest('.'));
 });
+
+if(watch){
+  gulp.watch('./src/*.js', gulp.parallel('default'));
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "LICENSE",
     "index.js",
     "overlay.js",
-    "styles.js"
+    "styles.js",
+    "toast.js",
+    "toast-container.js"
   ],
   "scripts": {
     "test": "zuul test/*.js --local --open",

--- a/src/index.js
+++ b/src/index.js
@@ -2,49 +2,89 @@
 
 const React = require('react');
 const noop = require('lodash/utility/noop');
+const delay = require('lodash/function/delay');
+const remove = require('lodash/array/remove');
 const assign = require('lodash/object/assign');
 
+const Toast = require('./toast');
 const Overlay = require('./overlay');
+const ToastContainer = require('./toast-container');
 
-function skrim(app, opts, done){
+function skrim(app, _, done){
 
   let renderer;
+  let toasts = [];
   let options = {
     shown: false,
     backdrop: true
   };
 
-  function show(extraOptions){
-    assign(options, { shown: true }, extraOptions);
+  function showOverlay(opts){
+    assign(options, { shown: true }, opts);
     app.render();
   }
 
-  function hide(){
+  function hideOverlay(){
     assign(options, { shown: false });
     app.render();
   }
 
-  function render(fn, extraOptions){
+  function renderOverlay(fn, opts){
     if(typeof fn === 'function'){
       renderer = fn;
     }
 
-    show(extraOptions);
+    showOverlay(opts);
+  }
+
+  function clearToast(component){
+    remove(toasts, component);
+    app.render();
+  }
+
+  function clearToasts(){
+    toasts = [];
+    app.render();
+  }
+
+  function showToast(message, opts = {}){
+    if(typeof message === 'string'){
+      const idx = toasts.length;
+      const component = (
+        <Toast key={idx} style={opts.style} onClose={() => clearToast(component)}>{message}</Toast>
+      );
+      toasts.push(component);
+      app.render();
+
+      if(opts.timeout){
+        delay(clearToast, opts.timeout, component);
+      }
+    }
   }
 
   app.expose('overlay', {
-    show: show,
-    hide: hide,
-    render: render
+    show: showOverlay,
+    hide: hideOverlay,
+    render: renderOverlay
+  });
+
+  app.expose('toast', {
+    show: showToast,
+    clear: clearToasts
   });
 
   app.view('overlay', function(el, cb){
     let component = (
-      <Overlay
-        hide={hide}
-        show={show}
-        renderer={options.shown ? renderer : noop}
-        {...options} />
+      <div>
+        <ToastContainer>
+          {toasts}
+        </ToastContainer>
+        <Overlay
+          hide={hideOverlay}
+          show={showOverlay}
+          renderer={options.shown ? renderer : noop}
+          {...options} />
+      </div>
     );
 
     React.render(component, el, cb);

--- a/src/styles.js
+++ b/src/styles.js
@@ -13,6 +13,33 @@ const styles = {
     left: 0,
     right: 0,
     backgroundColor: 'rgba(0,0,0,0.5)'
+  },
+  toastContainer: {
+    top: 60,
+    right: 0,
+    position: 'fixed'
+  },
+  toast: {
+    padding: 10,
+    minWidth: 150,
+    borderRadius: 2,
+    color: 'white',
+    fontWeight: 'bold',
+    marginBottom: 5,
+    backgroundColor: 'rgba(0,0,0,0.7)'
+  },
+  closeToastButton: {
+    background: 'none',
+    border: 0,
+    color: 'white',
+    fontSize: '1.2em',
+    padding: 0,
+    margin: 0,
+    float: 'right',
+    lineHeight: 0.8,
+    fontWeight: 'bold',
+    cursor: 'pointer',
+    marginLeft: 20
   }
 };
 

--- a/src/toast-container.js
+++ b/src/toast-container.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const React = require('react');
+
+const styles = require('./styles');
+
+class ToastContainer extends React.Component {
+
+  render(){
+    return (
+      <div style={styles.toastContainer}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+module.exports = ToastContainer;

--- a/src/toast.js
+++ b/src/toast.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const React = require('react');
+const assign = require('lodash/object/assign');
+
+const styles = require('./styles');
+
+class Toast extends React.Component {
+  constructor(){
+    this.onClose = this.onClose.bind(this);
+  }
+
+  onClose(evt){
+    if(typeof this.props.onClose === 'function'){
+      this.props.onClose(evt);
+    }
+  }
+
+  render(){
+    const toastStyles = assign({}, styles.toast, this.props.style);
+    const buttonStyles = assign({}, styles.closeToastButton, this.props.style);
+    const closeLabel = `Close Toast: ${this.props.children}`;
+
+    return (
+      <div style={toastStyles}>
+        {this.props.children}
+        <button style={buttonStyles} onClick={this.onClose} aria-label={closeLabel}>&times;</button>
+      </div>
+    );
+  }
+}
+
+module.exports = Toast;


### PR DESCRIPTION
#### What's this PR do?

Adds a `toast` API to the Skrim plugin for creating and closing toasts in the UI.
#### Where should the reviewer start?

`src/index.js` defines the public API and adds the `Toast` component to the skrim overlay mountpoint.
#### How should this be manually tested?

There's going to be a branch in Chrome IDE that you can try to compile invalid code.
#### Any background context you want to provide?

We needed toasts in the UI of Chrome IDE but I didn't want to compete with overlays for render passes, so the separate API allows both to co-exist.
#### Screenshots (if appropriate)

![Invalid tokenization](https://cloud.githubusercontent.com/assets/992373/7057370/c8eebf6a-de09-11e4-9fda-3f240e142feb.png)
